### PR TITLE
Unification support in resolving implicits

### DIFF
--- a/.depend
+++ b/.depend
@@ -1514,8 +1514,8 @@ typing/typeimplicit.cmo : \
     typing/path.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-    typing/ident.cmi \
     typing/env.cmi \
+    typing/btype.cmi \
     typing/typeimplicit.cmi
 typing/typeimplicit.cmx : \
     typing/types.cmx \
@@ -1524,8 +1524,8 @@ typing/typeimplicit.cmx : \
     typing/path.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
-    typing/ident.cmx \
     typing/env.cmx \
+    typing/btype.cmx \
     typing/typeimplicit.cmi
 typing/typeimplicit.cmi : \
     typing/types.cmi \

--- a/testsuite/tests/type-functors/implicits.ml
+++ b/testsuite/tests/type-functors/implicits.ml
@@ -473,3 +473,12 @@ let pack_unpack_functor {M : Option_monad} () =
 [%%expect{|
 val pack_unpack_functor : {M : Option_monad} -> unit -> int option = <fun>
 |}]
+
+let pack_unpack_functor_disambiguates {M : Monad} {O : Option_monad} () =
+  let module M = Monad_F_option(val pack {_}) in
+  M.return 15;;
+
+[%%expect{|
+val pack_unpack_functor_disambiguates :
+  {M : Monad} -> {O : Option_monad} -> unit -> int option = <fun>
+|}]

--- a/testsuite/tests/type-functors/implicits.ml
+++ b/testsuite/tests/type-functors/implicits.ml
@@ -164,3 +164,50 @@ Line 1, characters 21-39:
 Error: This expression has type int ?M.t * unit ?M.t * int list ?M.t
        but an expression was expected of type bool
 |}]
+
+let level_lower_excludes_candidates {M : Monad} =
+  let x = ref None in
+  fun {N : Monad} ->
+    (* This assignment lowers the level of the implicit argument's [t] below
+       that of N, so it should be excluded as a candidate.
+    *)
+    x := Some (return {_} 15);
+    !x;;
+
+[%%expect{|
+val level_lower_excludes_candidates :
+  {M : Monad} -> {N : Monad} -> int M.t option = <fun>
+|}]
+
+let level_lower_excludes_candidates_fail () =
+  let x = ref None in
+  fun {N : Monad} ->
+    (* This assignment lowers the level of the implicit argument's [t] below
+       that of N, so it should be excluded as a candidate.
+    *)
+    x := Some (return {_} 15);
+    !x;;
+
+[%%expect{|
+Line 7, characters 23-24:
+7 |     x := Some (return {_} 15);
+                           ^
+Error: This implicit argument is ambiguous.
+       No candidate instances were found.
+       Hint: Consider passing the desired instance directly.
+|}]
+
+let level_lower_expands_type () =
+  let x = ref None in
+  fun {N : Option_monad} ->
+    (* This assignment lowers the level of the implicit argument's [t] below
+       that of N, but it should still be accepted as a candidate by expanding
+       ['a t = 'a option].
+    *)
+    x := Some (return {_} 15);
+    !x;;
+
+[%%expect{|
+val level_lower_expands_type :
+  unit -> {N : Option_monad} -> int option option = <fun>
+|}]

--- a/testsuite/tests/type-functors/implicits.ml
+++ b/testsuite/tests/type-functors/implicits.ml
@@ -482,3 +482,150 @@ let pack_unpack_functor_disambiguates {M : Monad} {O : Option_monad} () =
 val pack_unpack_functor_disambiguates :
   {M : Monad} -> {O : Option_monad} -> unit -> int option = <fun>
 |}]
+
+module type Variant_type = sig type t = A | B end;;
+
+let ret_variant_type {T : Variant_type} (x : T.t) = x;;
+
+[%%expect{|
+module type Variant_type = sig type t = A | B end
+val ret_variant_type : {T : Variant_type} -> T.t -> T.t = <fun>
+|}]
+
+let unqualified_variant_type {T : Variant_type} () =
+  ret_variant_type {_} A;;
+
+[%%expect{|
+val unqualified_variant_type : {T : Variant_type} -> unit -> T.t = <fun>
+|}]
+
+let qualified_variant_type {T : Variant_type} () =
+  ret_variant_type {_} T.A;;
+
+[%%expect{|
+val qualified_variant_type : {T : Variant_type} -> unit -> T.t = <fun>
+|}]
+
+let ambiguous_variant_type_fail {T1 : Variant_type} {T2 : Variant_type} () =
+  ret_variant_type {_} A;;
+
+[%%expect{|
+Line 2, characters 20-21:
+2 |   ret_variant_type {_} A;;
+                        ^
+Error: This implicit argument is ambiguous.
+       Could not choose between the candidates: T2 T1.
+       Hint: Consider passing the desired instance directly.
+|}]
+
+let qualified_variant_type_disambiguates {T1 : Variant_type}
+    {T2 : Variant_type} () =
+  ret_variant_type {_} T1.A;;
+
+[%%expect{|
+val qualified_variant_type_disambiguates :
+  {T1 : Variant_type} -> {T2 : Variant_type} -> unit -> T1.t = <fun>
+|}]
+
+module Variant_type = struct type t = A | B end;;
+
+[%%expect{|
+module Variant_type : sig type t = A | B end
+|}]
+
+let variant_type_adds_constraint () = ret_variant_type {_} Variant_type.A;;
+
+[%%expect{|
+Line 1, characters 56-57:
+1 | let variant_type_adds_constraint () = ret_variant_type {_} Variant_type.A;;
+                                                            ^
+Error: This implicit argument is ambiguous.
+       No candidate instances were found.
+       Considered constraints:
+         ?T.t = Variant_type.t.
+       Hint: Consider passing the desired instance directly.
+|}, Principal{|
+Line 1, characters 56-57:
+1 | let variant_type_adds_constraint () = ret_variant_type {_} Variant_type.A;;
+                                                            ^
+Error: This implicit argument is ambiguous.
+       No candidate instances were found.
+       Considered constraints:
+         ?T.t = Variant_type.t
+         ?T.t = Variant_type.t.
+       Hint: Consider passing the desired instance directly.
+|}]
+
+module type Record_type = sig type t = {x: int; y: 'a. 'a -> 'a} end;;
+
+let ret_record_type {T : Record_type} (x : T.t) = x;;
+
+[%%expect{|
+module type Record_type = sig type t = { x : int; y : 'a. 'a -> 'a; } end
+val ret_record_type : {T : Record_type} -> T.t -> T.t = <fun>
+|}]
+
+let unqualified_record_type {T : Record_type} () =
+  ret_record_type {_} {x= 15; y= fun x -> x};;
+
+[%%expect{|
+val unqualified_record_type : {T : Record_type} -> unit -> T.t = <fun>
+|}]
+
+let qualified_record_type {T : Record_type} () =
+  ret_record_type {_} {T.x= 15; y= fun x -> x};;
+
+[%%expect{|
+val qualified_record_type : {T : Record_type} -> unit -> T.t = <fun>
+|}]
+
+let ambiguous_record_type_fail {T1 : Record_type} {T2 : Record_type} () =
+  ret_record_type {_} {x= 15; y= fun x -> x};;
+
+[%%expect{|
+Line 2, characters 19-20:
+2 |   ret_record_type {_} {x= 15; y= fun x -> x};;
+                       ^
+Error: This implicit argument is ambiguous.
+       Could not choose between the candidates: T2 T1.
+       Hint: Consider passing the desired instance directly.
+|}]
+
+let qualified_record_type_disambiguates {T1 : Record_type}
+    {T2 : Record_type} () =
+  ret_record_type {_} {T1.x= 15; y= fun x -> x};;
+
+[%%expect{|
+val qualified_record_type_disambiguates :
+  {T1 : Record_type} -> {T2 : Record_type} -> unit -> T1.t = <fun>
+|}]
+
+module Record_type = struct type t = {x: int; y: 'a. 'a -> 'a} end;;
+
+[%%expect{|
+module Record_type : sig type t = { x : int; y : 'a. 'a -> 'a; } end
+|}]
+
+let record_type_adds_constraint () =
+  ret_record_type {_} {Record_type.x= 15; y= fun x -> x};;
+
+[%%expect{|
+Line 2, characters 19-20:
+2 |   ret_record_type {_} {Record_type.x= 15; y= fun x -> x};;
+                       ^
+Error: This implicit argument is ambiguous.
+       No candidate instances were found.
+       Considered constraints:
+         ?T.t = Record_type.t.
+       Hint: Consider passing the desired instance directly.
+|}, Principal{|
+Line 2, characters 19-20:
+2 |   ret_record_type {_} {Record_type.x= 15; y= fun x -> x};;
+                       ^
+Error: This implicit argument is ambiguous.
+       No candidate instances were found.
+       Considered constraints:
+         ?T.t = Record_type.t
+         ?T.t = Record_type.t.
+       Hint: Consider passing the desired instance directly.
+|}]

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -81,6 +81,8 @@ type change =
   | Cident_scope of Ident.t * int
   | Cident_instance of Ident.t
   | Cimplicit_deferred of (unit -> unit)
+  | Csubst of
+      (type_expr * type_expr) list ref * (type_expr * type_expr) list
 
 type changes =
     Change of change * changes ref
@@ -746,6 +748,7 @@ let undo_change = function
   | Cident_scope (ident, scope) -> Ident.set_instantiation_scope ident scope
   | Cident_instance ident -> Ident.clear_instantiation ident
   | Cimplicit_deferred undo -> undo ()
+  | Csubst (r, v) -> r := v
 
 type snapshot = changes ref * int
 let last_snapshot = s_ref 0
@@ -806,6 +809,7 @@ let set_ident_scope ident scope =
 let set_ident_instance ident path =
   log_change (Cident_instance ident); Ident.set_instantiation ident path
 let log_implicit_deferred undo = log_change (Cimplicit_deferred undo)
+let log_subst rs v = log_change (Csubst (rs, v))
 
 let snapshot () =
   let old = !last_snapshot in

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -249,6 +249,9 @@ val set_univar: type_expr option ref -> type_expr -> unit
 val set_kind: field_kind option ref -> field_kind -> unit
 val set_commu: commutable ref -> commutable -> unit
         (* Set references, logging the old value *)
+val set_ident_scope: Ident.t -> int -> unit
+val set_ident_instance: Ident.t -> Path.t -> unit
+val log_implicit_deferred: (unit -> unit) -> unit
 
 (**** Forward declarations ****)
 val print_raw: (Format.formatter -> type_expr -> unit) ref

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -252,6 +252,8 @@ val set_commu: commutable ref -> commutable -> unit
 val set_ident_scope: Ident.t -> int -> unit
 val set_ident_instance: Ident.t -> Path.t -> unit
 val log_implicit_deferred: (unit -> unit) -> unit
+val log_subst:
+  (type_expr * type_expr) list ref -> (type_expr * type_expr) list -> unit
 
 (**** Forward declarations ****)
 val print_raw: (Format.formatter -> type_expr -> unit) ref

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3384,16 +3384,19 @@ and unify3 ?(stub_unify = false) env id_pairs1 id_pairs2 t1 t1' t2 t2' =
             mcomp !env id_pairs1 id_pairs2 t1' t2';
             record_equation t1' t2'
           )
-      | (Tconstr (path1, _, _), Tconstr (path2, _, _))
-        when List.exists Ident.is_instantiable (Path.heads path1) ->
+      | (Tconstr (path, _, _), _)
+        when List.exists Ident.is_instantiable (Path.heads path) ->
           (* Defer checks instead of failing. *)
-          add_deferred_checks add_implicit_deferred_check_1 path1;
-          add_deferred_checks add_implicit_deferred_check_1 path2;
-      | (Tconstr (path1, _, _), Tconstr (path2, _, _))
-        when List.exists Ident.is_instantiable (Path.heads path2) ->
+          add_deferred_checks add_implicit_deferred_check_1 path;
+          begin match d2 with
+          | Tconstr (path, _, _) ->
+              add_deferred_checks add_implicit_deferred_check_1 path
+          | _ -> ()
+          end
+      | (_, Tconstr (path, _, _))
+        when List.exists Ident.is_instantiable (Path.heads path) ->
           (* Defer checks instead of failing. *)
-          add_deferred_checks add_implicit_deferred_check_2 path1;
-          add_deferred_checks add_implicit_deferred_check_2 path2;
+          add_deferred_checks add_implicit_deferred_check_2 path;
           (* [t2]'s head type is more concrete than [t1]'s, switch the link. *)
           set_type_desc t1' d1;
           link_type t2' t1'

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -108,6 +108,7 @@ val is_functor_arg: Path.t -> t -> bool
 
 val open_implicit_hole_scope: scope:int -> t -> t
 val add_implicit_hole: implicit_hole -> t -> unit
+val add_implicit_deferred_check: Ident.t -> implicit_deferred -> t -> unit
 val implicit_holes: t -> implicit_hole list
 val implicit_hole_scope: t -> int
 

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -192,6 +192,15 @@ let set_instantiation id path =
       x.path <- Some path
   | _ -> Misc.fatal_errorf "Ident.set_instantiation %s" (name id)
 
+let clear_instantiation id =
+  match id with
+  | Instantiable {path= None} ->
+      Misc.fatal_errorf "Ident.clear_instantiation %s: Not instantiated"
+        (name id)
+  | Instantiable x ->
+      x.path <- None
+  | _ -> Misc.fatal_errorf "Ident.clear_instantiation %s" (name id)
+
 let set_instantiation_scope id scope =
   match id with
   | Instantiable x -> x.scope <- scope

--- a/typing/ident.mli
+++ b/typing/ident.mli
@@ -73,11 +73,19 @@ val instantiation: t -> path option
 
 val set_instantiation: t -> path -> unit
         (** Instantiate an instantiable ident.
+            This should be called via [Btype.set_ident_instance].
             @raise [Fatal_error] if called on a non-instantiable ident, or if
             the instantiable ident has already been instantiated. *)
 
+val clear_instantiation: t -> unit
+        (** Clear an instantiated instantiable ident.
+            This is for use by [Btype], and should not be called directly.
+            @raise [Fatal_error] if called on a non-instantiable ident, or if
+            the instantiable ident hasn't been instantiated. *)
+
 val set_instantiation_scope: t -> int -> unit
         (** Set the scope of an instantiable ident.
+            This should be called via [Btype.set_ident_scope].
             @raise [Fatal_error] if called on a non-instantiable ident. *)
 
 val scope: t -> int

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3849,7 +3849,10 @@ and type_expect_
       let scope = Env.implicit_hole_scope env in
       let ident = Ident.create_instantiable ~scope name in
       Env.add_implicit_hole
-        {ihl_loc=lid.loc; ihl_ident=ident; ihl_module_type= mty}
+        { ihl_loc=lid.loc
+        ; ihl_ident=ident
+        ; ihl_module_type= mty
+        ; ihl_deferreds= [] }
         env;
       let modl =
         { mod_desc=

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -631,7 +631,11 @@ let rec expand_path env p =
       if Path.same p p' then p else expand_path env p'
 
 let compare_type_path env tpath1 tpath2 =
-  Path.same (expand_path env tpath1) (expand_path env tpath2)
+  let tpath1' = expand_path env tpath1 in
+  let tpath2' = expand_path env tpath2 in
+  Path.same tpath1' tpath2'
+  || List.exists Ident.is_instantiable (Path.heads tpath1')
+  || List.exists Ident.is_instantiable (Path.heads tpath2')
 
 (* Records *)
 exception Wrong_name_disambiguation of Env.t * wrong_name

--- a/typing/typeimplicit.ml
+++ b/typing/typeimplicit.ml
@@ -26,55 +26,135 @@ let run_implicit_deferred = function
   | Types.Idfr_scope_escape run -> run ()
   | Types.Idfr_update_level run -> run ()
   | Types.Idfr_unify (_ty1, _ty2, run) -> run ()
+  | Types.Idfr_marker -> ()
 
 let resolve_implicits env =
   let implicit_instances =
     List.map (fun path -> (path, Env.find_module path env))
       (Env.implicit_instances env)
   in
-  List.map (fun ({Types.ihl_loc= loc; ihl_ident= id} as implicit_hole) ->
-      let candidates =
-        List.filter_map
-          (fun (path, md) ->
-            let snap = Btype.snapshot () in
-            try
-              let mod_expr =
-                { mod_desc=
-                    Tmod_ident (path, Location.mknoloc (Longident.Lident "_"))
-                ; mod_loc= loc
-                ; mod_type= md.Types.md_type
-                ; mod_env= env
-                ; mod_attributes= [] }
+  let instantiate_implicit implicit_hole path =
+    Btype.set_ident_instance implicit_hole.Types.ihl_ident path;
+    Btype.set_ident_scope implicit_hole.Types.ihl_ident (Path.scope path);
+    List.iter run_implicit_deferred implicit_hole.Types.ihl_deferreds
+  in
+  let implicit_holes = Env.implicit_holes env in
+  List.iter (fun {Types.ihl_ident= id; _} ->
+      Env.add_implicit_deferred_check id Types.Idfr_marker env )
+    implicit_holes;
+  let candidates =
+    List.map (fun ({Types.ihl_loc= loc; ihl_ident= id; _} as implicit_hole) ->
+        let candidates =
+          List.filter_map
+            (fun (path, md) ->
+              let snap = Btype.snapshot () in
+              try
+                assert (Path.scope path <= Ident.scope id);
+                let mod_expr =
+                  { mod_desc=
+                      Tmod_ident
+                        (path, Location.mknoloc (Longident.Lident "_"))
+                  ; mod_loc= loc
+                  ; mod_type= md.Types.md_type
+                  ; mod_env= env
+                  ; mod_attributes= [] }
+                in
+                let modl =
+                  !wrap_constraint env mod_expr implicit_hole.ihl_module_type
+                in
+                instantiate_implicit implicit_hole path;
+                Btype.backtrack snap;
+                Some (path, modl)
+              with _ -> Btype.backtrack snap; None )
+            implicit_instances
+        in
+        begin match candidates with
+        | [(path, _modl)] -> instantiate_implicit implicit_hole path
+        | [] ->
+            let equalities =
+              List.filter_map (function
+                  | Types.Idfr_unify (ty1, ty2, _run) -> Some (ty1, ty2)
+                  | _ -> None)
+                implicit_hole.ihl_deferreds
+            in
+            raise
+              (Error (loc, env, Ambiguous_functor_argument ([], equalities)))
+        | _ -> ()
+        end;
+        candidates )
+    implicit_holes
+  in
+  let rec go candidates =
+    (* Invariant: if candidates = [_] then it has already been instantiated. *)
+    let is_finished = ref true in
+    let implicit_holes = Env.implicit_holes env in
+    List.iter (fun {Types.ihl_ident= id; _} ->
+        Env.add_implicit_deferred_check id Idfr_marker env )
+      implicit_holes;
+    let candidates =
+      List.map2
+        (fun ({Types.ihl_loc= loc; _} as implicit_hole) candidates ->
+          match candidates with
+          | [_] -> candidates
+          | _ ->
+              let candidates =
+                List.filter_map
+                  (fun (path, modl) ->
+                    let snap = Btype.snapshot () in
+                    try
+                      instantiate_implicit implicit_hole path;
+                      Btype.backtrack snap;
+                      Some (path, modl)
+                    with _ -> Btype.backtrack snap; None )
+                  candidates
               in
-              let modl =
-                !wrap_constraint env mod_expr implicit_hole.ihl_module_type
-              in
-              Btype.set_ident_instance id path;
-              Btype.set_ident_scope id (Path.scope path);
-              List.iter run_implicit_deferred implicit_hole.ihl_deferreds;
-              Btype.backtrack snap;
-              Some (path, modl)
-            with _ -> Btype.backtrack snap; None )
-          implicit_instances
+              begin match candidates with
+              | [(path, _modl)] -> instantiate_implicit implicit_hole path
+              | [] ->
+                  let equalities =
+                    List.filter_map (function
+                        | Types.Idfr_unify (ty1, ty2, _run) -> Some (ty1, ty2)
+                        | _ -> None)
+                      implicit_hole.ihl_deferreds
+                  in
+                  raise
+                    (Error
+                      (loc, env, Ambiguous_functor_argument ([], equalities)))
+              | _ ->
+                  match implicit_hole.ihl_deferreds with
+                  | Types.Idfr_marker :: _ ->
+                      (* No further progress was made for this hole. *)
+                      ()
+                  | _ ->
+                      (* Additional constraints were found. *)
+                      is_finished := false
+              end;
+              candidates )
+        implicit_holes candidates
       in
-      match candidates with
-      | [(path, modl)] ->
-          Btype.set_ident_instance id path;
-          Btype.set_ident_scope id (Path.scope path);
-          List.iter run_implicit_deferred implicit_hole.ihl_deferreds;
-          (id, loc, modl)
-      | _ ->
-          let candidates = List.map fst candidates in
-          let equalities =
-            List.filter_map (function
-                | Types.Idfr_unify (ty1, ty2, _run) -> Some (ty1, ty2)
-                | _ -> None)
-              implicit_hole.ihl_deferreds
-          in
-          raise
-            (Error
-              (loc, env, Ambiguous_functor_argument (candidates, equalities))))
-    (Env.implicit_holes env)
+      if !is_finished then
+        List.map2
+          (fun
+              ({Types.ihl_loc= loc; ihl_ident= id; _} as implicit_hole)
+              candidates ->
+            match candidates with
+            | [(_path, modl)] -> (id, loc, modl)
+            | _ ->
+                let candidates = List.map fst candidates in
+                let equalities =
+                  List.filter_map (function
+                      | Types.Idfr_unify (ty1, ty2, _run) -> Some (ty1, ty2)
+                      | _ -> None)
+                    implicit_hole.Types.ihl_deferreds
+                in
+                raise
+                  (Error
+                    ( loc, env
+                    , Ambiguous_functor_argument (candidates, equalities))) )
+          implicit_holes candidates
+      else go candidates
+  in
+  go candidates
 
 open Format
 

--- a/typing/typeimplicit.mli
+++ b/typing/typeimplicit.mli
@@ -13,7 +13,8 @@
 open Typedtree
 
 type error =
-  | Ambiguous_functor_argument of Path.t list
+  | Ambiguous_functor_argument of
+      Path.t list * (Types.type_desc * Types.type_expr) list
 
 exception Error of Location.t * Env.t * error
 

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -438,6 +438,8 @@ type implicit_deferred =
     Idfr_scope_escape of (unit -> unit)
   | Idfr_update_level of (unit -> unit)
   | Idfr_unify of type_desc * type_expr * (unit -> unit)
+  | Idfr_marker                         (* Mark current progress to detect
+                                           further deferred computations *)
 
 type implicit_hole =
   { ihl_ident: Ident.t

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -437,6 +437,7 @@ and constructor_tag =
 type implicit_deferred =
     Idfr_scope_escape of (unit -> unit)
   | Idfr_update_level of (unit -> unit)
+  | Idfr_unify of type_desc * type_expr * (unit -> unit)
 
 type implicit_hole =
   { ihl_ident: Ident.t

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -434,10 +434,15 @@ and constructor_tag =
   | Cstr_extension of Path.t * bool     (* Extension constructor
                                            true if a constant false if a block*)
 
+type implicit_deferred =
+    Idfr_scope_escape of (unit -> unit)
+  | Idfr_update_level of (unit -> unit)
+
 type implicit_hole =
   { ihl_ident: Ident.t
   ; ihl_loc: Location.t
-  ; ihl_module_type: module_type }
+  ; ihl_module_type: module_type
+  ; ihl_deferreds: implicit_deferred list }
 
 let equal_tag t1 t2 =
   match (t1, t2) with

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -575,6 +575,7 @@ and constructor_tag =
 type implicit_deferred =
     Idfr_scope_escape of (unit -> unit)
   | Idfr_update_level of (unit -> unit)
+  | Idfr_unify of type_desc * type_expr * (unit -> unit)
 
 type implicit_hole =
   { ihl_ident: Ident.t

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -572,10 +572,15 @@ and constructor_tag =
   | Cstr_extension of Path.t * bool     (* Extension constructor
                                            true if a constant false if a block*)
 
+type implicit_deferred =
+    Idfr_scope_escape of (unit -> unit)
+  | Idfr_update_level of (unit -> unit)
+
 type implicit_hole =
   { ihl_ident: Ident.t
   ; ihl_loc: Location.t
-  ; ihl_module_type: module_type }
+  ; ihl_module_type: module_type
+  ; ihl_deferreds: implicit_deferred list }
 
 (* Constructors are the same *)
 val equal_tag :  constructor_tag -> constructor_tag -> bool

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -576,6 +576,8 @@ type implicit_deferred =
     Idfr_scope_escape of (unit -> unit)
   | Idfr_update_level of (unit -> unit)
   | Idfr_unify of type_desc * type_expr * (unit -> unit)
+  | Idfr_marker                         (* Mark current progress to detect
+                                           further deferred computations *)
 
 type implicit_hole =
   { ihl_ident: Ident.t


### PR DESCRIPTION
This PR adds support for unification with types from implicit modules.

This uses a simple naive approach:
* scope modifications, escape checks, and unification which rely on the implicit instance are deferred in `unit -> unit` functions
* instance search runs these deferred tests for each candidate instance for each implicit module
  - an implicit module is resolved if there is exactly 1 candidate instance, at which point the deferred checks are evaluated
  - search is considered to have 'made progress' if there are new deferred checks added, which happens as a result of some other implicit module having been resolved
  - search terminates when it stops making progress.

This PR doesn't handle sharing from unification, so in e.g. `{M : S} -> int M.t -> int M.t` each `int M.t` may unify with a different, potentially-incompatible type if they are not the same `type_expr`. This still results in an error, but it appears at the instance search stage instead of the unification stage.